### PR TITLE
Enable stacker feature in full-moon

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,6 +44,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c676a478f63e9fa2dd5368a42f28bba0d6c560b775f38583c8bbaa7fcd67c9c"
 
 [[package]]
+name = "cc"
+version = "1.0.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -155,6 +164,7 @@ dependencies = [
  "paste",
  "serde",
  "smol_str",
+ "stacker",
 ]
 
 [[package]]
@@ -299,6 +309,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "psm"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5787f7cda34e3033a72192c018bc5883100330f362ef279a8cbccfce8bb4e874"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -372,6 +391,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7475118a28b7e3a2e157ce0131ba8c5526ea96e90ee601d9f6bb2e286a35ab44"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "stacker"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c886bd4480155fd3ef527d45e9ac8dd7118a898a46530b7b94c3e21866259fce"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "psm",
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,10 @@ anyhow = "1.0"
 clap = { version = "3.2.5", features = ["derive"] }
 console = "0.15.7"
 env_logger = { version = "0.10.1", default-features = false }
-full_moon = { version = "0.19.0", features = ["roblox"] }
+full_moon = { version = "0.19.0", features = ["roblox", "stacker"] }
 log = "0.4.20"
 serde = "1.0.137"
 serde_json = "1.0.81"
+
+[profile.dev.package.full_moon]
+opt-level = 3


### PR DESCRIPTION
Enables the stacker feature in full-moon as suggested here https://github.com/JohnnyMorganz/wally-package-types/issues/7, which seems to fix the stack overflow issues introduced in v1.3.0.

I also made sure to always compile full-moon in release mode which was suggested here https://github.com/Kampfkarren/full-moon/issues/140#issuecomment-925954867.