### PR TITLE
Support multiple package folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+.DS_Store


### PR DESCRIPTION
This PR allows for the transformation of multiple package directories at once. The most common example is:

```bash
wally-package-types --sourcemap sourcemap.json Packages ServerPackages
```

instead of:

```bash
wally-package-types --sourcemap sourcemap.json Packages &&
wally-package-types --sourcemap sourcemap.json ServerPackages
```