### PR TITLE
Actually fix macOS release targets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
           profile: minimal
 
       - name: Build Binary (All features)
-        run: cargo build --verbose --locked --release --all-features
+        run: cargo build --verbose --locked --release --all-features --target ${{ matrix.cargo-target }}
         env:
           CARGO_TARGET_DIR: output
 


### PR DESCRIPTION
It turns out that we forget to pass `--target` to the cargo build command, meaning we don't actually build for the cargo target that we specified in the matrix. This means that we will build arm64 binaries for old Intel macbooks still