### PR TITLE
Fix invalid Luau type stubs when later generic default is stripped

### DIFF
--- a/src/link_mutator.rs
+++ b/src/link_mutator.rs
@@ -46,7 +46,8 @@ fn strip_unknown_default_generics(
     generics: &GenericDeclaration,
     resolved_types: &[String],
 ) -> Punctuated<GenericDeclarationParameter> {
-    generics
+    // First pass: strip defaults that reference unknown types
+    let stripped: Vec<_> = generics
         .generics()
         .pairs()
         .map(|pair| {
@@ -55,7 +56,29 @@ fn strip_unknown_default_generics(
                 _ => decl.with_default(None),
             })
         })
-        .collect::<Punctuated<_>>()
+        .collect();
+
+    // In Luau, once a parameter has a default, all subsequent parameters must also have defaults.
+    // Find the last parameter without a default, and strip defaults from all parameters before it
+    // to avoid generating invalid "State = any, Dispatchers" style declarations.
+    let last_no_default_idx = stripped
+        .iter()
+        .rposition(|pair| pair.value().default_type().is_none());
+
+    match last_no_default_idx {
+        None => stripped.into_iter().collect(),
+        Some(last_idx) => stripped
+            .into_iter()
+            .enumerate()
+            .map(|(i, pair)| {
+                if i < last_idx {
+                    pair.map(|decl| decl.with_default(None))
+                } else {
+                    pair
+                }
+            })
+            .collect(),
+    }
 }
 
 pub fn create_new_type_declaration(
@@ -316,6 +339,27 @@ mod tests {
         assert_eq!(
             reexported_type_declarations[1].0.to_string(),
             "export type Value<T, S = Action> = REQUIRED_MODULE.Value<T, S >"
+        );
+    }
+
+    #[test]
+    fn strips_earlier_defaults_when_later_param_has_unknown_default() {
+        // Luau requires that once a param has a default, all subsequent params must too.
+        // If a later param's default is stripped (unknown type), earlier defaults must also be stripped.
+        // This matches the Reflex `Producer<State = any, Dispatchers = ExternalType>` case from issue #27.
+        let code = r"
+            export type Producer<State = any, Dispatchers = ExternalType> = Types.Producer<State, Dispatchers>
+        ";
+
+        let type_declarations = type_declarations_from_source(code).unwrap();
+        assert_eq!(type_declarations.len(), 1);
+
+        let reexported_type_declarations = re_export_type_declarations(type_declarations);
+        assert_eq!(reexported_type_declarations.len(), 1);
+
+        assert_eq!(
+            reexported_type_declarations[0].0.to_string(),
+            "export type Producer<State , Dispatchers > = REQUIRED_MODULE.Producer<State , Dispatchers >"
         );
     }
 }

--- a/src/link_mutator.rs
+++ b/src/link_mutator.rs
@@ -46,39 +46,36 @@ fn strip_unknown_default_generics(
     generics: &GenericDeclaration,
     resolved_types: &[String],
 ) -> Punctuated<GenericDeclarationParameter> {
-    // First pass: strip defaults that reference unknown types
-    let stripped: Vec<_> = generics
-        .generics()
-        .pairs()
-        .map(|pair| {
-            pair.clone().map(|decl| match decl.default_type() {
-                Some(type_info) if should_keep_default_type(type_info, resolved_types) => decl,
-                _ => decl.with_default(None),
-            })
-        })
-        .collect();
+    let pairs: Vec<_> = generics.generics().pairs().collect();
 
-    // In Luau, once a parameter has a default, all subsequent parameters must also have defaults.
-    // Find the last parameter without a default, and strip defaults from all parameters before it
-    // to avoid generating invalid "State = any, Dispatchers" style declarations.
-    let last_no_default_idx = stripped
-        .iter()
-        .rposition(|pair| pair.value().default_type().is_none());
+    // Luau requires that once a parameter has a default, all subsequent ones must too.
+    // Find the last parameter that will end up without a default (originally lacked one, or
+    // has an unknown default that gets stripped). All parameters before it must also lose defaults.
+    let last_no_default_idx = pairs.iter().rposition(|pair| {
+        match pair.value().default_type() {
+            Some(type_info) => !should_keep_default_type(type_info, resolved_types),
+            None => true,
+        }
+    });
 
-    match last_no_default_idx {
-        None => stripped.into_iter().collect(),
-        Some(last_idx) => stripped
-            .into_iter()
-            .enumerate()
-            .map(|(i, pair)| {
-                if i < last_idx {
-                    pair.map(|decl| decl.with_default(None))
+    pairs
+        .into_iter()
+        .enumerate()
+        .map(|(i, pair)| {
+            pair.clone().map(|decl| {
+                if last_no_default_idx.map_or(false, |last| i <= last) {
+                    decl.with_default(None)
                 } else {
-                    pair
+                    match decl.default_type() {
+                        Some(type_info) if should_keep_default_type(type_info, resolved_types) => {
+                            decl
+                        }
+                        _ => decl.with_default(None),
+                    }
                 }
             })
-            .collect(),
-    }
+        })
+        .collect()
 }
 
 pub fn create_new_type_declaration(
@@ -344,9 +341,6 @@ mod tests {
 
     #[test]
     fn strips_earlier_defaults_when_later_param_has_unknown_default() {
-        // Luau requires that once a param has a default, all subsequent params must too.
-        // If a later param's default is stripped (unknown type), earlier defaults must also be stripped.
-        // This matches the Reflex `Producer<State = any, Dispatchers = ExternalType>` case from issue #27.
         let code = r"
             export type Producer<State = any, Dispatchers = ExternalType> = Types.Producer<State, Dispatchers>
         ";

--- a/src/link_mutator.rs
+++ b/src/link_mutator.rs
@@ -42,6 +42,13 @@ fn should_keep_default_type(type_info: &TypeInfo, resolved_types: &[String]) -> 
     }
 }
 
+fn will_strip_default(decl: &GenericDeclarationParameter, resolved_types: &[String]) -> bool {
+    match decl.default_type() {
+        Some(type_info) => !should_keep_default_type(type_info, resolved_types),
+        None => true,
+    }
+}
+
 fn strip_unknown_default_generics(
     generics: &GenericDeclaration,
     resolved_types: &[String],
@@ -51,12 +58,9 @@ fn strip_unknown_default_generics(
     // Luau requires that once a parameter has a default, all subsequent ones must too.
     // Find the last parameter that will end up without a default (originally lacked one, or
     // has an unknown default that gets stripped). All parameters before it must also lose defaults.
-    let last_no_default_idx = pairs.iter().rposition(|pair| {
-        match pair.value().default_type() {
-            Some(type_info) => !should_keep_default_type(type_info, resolved_types),
-            None => true,
-        }
-    });
+    let last_no_default_idx = pairs
+        .iter()
+        .rposition(|pair| will_strip_default(pair.value(), resolved_types));
 
     pairs
         .into_iter()
@@ -66,12 +70,7 @@ fn strip_unknown_default_generics(
                 if last_no_default_idx.map_or(false, |last| i <= last) {
                     decl.with_default(None)
                 } else {
-                    match decl.default_type() {
-                        Some(type_info) if should_keep_default_type(type_info, resolved_types) => {
-                            decl
-                        }
-                        _ => decl.with_default(None),
-                    }
+                    decl
                 }
             })
         })


### PR DESCRIPTION
In Luau, once a generic parameter has a default, all subsequent parameters
must also have defaults. When wally-package-types stripped an unknown default
from a later parameter (e.g. Dispatchers = ExternalType → Dispatchers), it
left earlier defaulted parameters intact (State = any), producing invalid
output like `Producer<State = any, Dispatchers>`.

The fix adds a second pass to strip_unknown_default_generics: after removing
unknown defaults, find the last parameter without a default and remove
defaults from all parameters before it.

Fixes #27